### PR TITLE
fix timer init in repository sync

### DIFF
--- a/repository.go
+++ b/repository.go
@@ -40,13 +40,10 @@ func newRepository(options repositoryOptions, channels repositoryChannels) *repo
 
 func (r *repository) sync() {
 	defer r.cleanup()
-
-	refreshTimer := time.NewTimer(r.options.refreshInterval)
-
 	r.fetch()
 	r.ready <- true
-
 	for {
+		refreshTimer := time.NewTimer(r.options.refreshInterval)
 		select {
 		case <-r.close:
 			refreshTimer.Stop()

--- a/repository.go
+++ b/repository.go
@@ -42,13 +42,13 @@ func (r *repository) sync() {
 	defer r.cleanup()
 	r.fetch()
 	r.ready <- true
+	refreshTicker := time.NewTicker(r.options.refreshInterval)
 	for {
-		refreshTimer := time.NewTimer(r.options.refreshInterval)
 		select {
 		case <-r.close:
-			refreshTimer.Stop()
+			refreshTicker.Stop()
 			return
-		case <-refreshTimer.C:
+		case <-refreshTicker.C:
 			r.fetch()
 		}
 	}


### PR DESCRIPTION
Move the timer initialization in the loop, so a new timer is used after each sync, and a new event is triggered. Otherwise, the `sync` rountine halts after the first sync.